### PR TITLE
Fix bug in create_subfolder

### DIFF
--- a/openrelik_api_client/folders.py
+++ b/openrelik_api_client/folders.py
@@ -57,8 +57,8 @@ class FoldersAPI:
         Raises:
             HTTPError: If the API request failed.
         """
-        folder_id = None
         endpoint = f"{self.api_client.base_url}/folders/{folder_id}/folders"
+        folder_id = None
         data = {"display_name": display_name}
         response = self.api_client.session.post(endpoint, json=data)
         response.raise_for_status()


### PR DESCRIPTION
`folder_id = None` to be set after `folder_id` is used to construct the `endpoint`.
Otherwise, all calls to `create_subfolder` will fail.