### PR TITLE
Add template_params to workflow creation

### DIFF
--- a/openrelik_api_client/workflows.py
+++ b/openrelik_api_client/workflows.py
@@ -25,7 +25,7 @@ class WorkflowsAPI:
         self.folders_url = f"{self.api_client.base_url}/folders"
 
     def create_workflow(
-        self, folder_id: int, file_ids: list, template_id: int = None
+        self, folder_id: int, file_ids: list, template_id: int = None, template_params: dict = {}
     ) -> int | None:
         """Creates a new workflow.
 
@@ -46,6 +46,7 @@ class WorkflowsAPI:
             "folder_id": folder_id,
             "file_ids": file_ids,
             "template_id": template_id,
+            "template_params": template_params,
         }
         response = self.api_client.session.post(endpoint, json=data)
         response.raise_for_status()


### PR DESCRIPTION
### Summary
Passes `template_params` dictionary during workflow creation.

### Technical Details:
*   **Function Signature Modification:** The `create_workflow` method in `openrelik_api_client/workflows.py` now accepts an optional `template_params` dictionary. This change allows users to provide parameters that customize the workflow execution based on the selected template.
*   **Request Payload Update:** The `create_workflow` method has been updated to include the `template_params` in the JSON payload sent to the API endpoint. This addition lets users pass dynamic parameters to their workflows.